### PR TITLE
✨ [Feat] 음식 간편추가 UI 구현

### DIFF
--- a/components/quickAdd/NutrientInput.tsx
+++ b/components/quickAdd/NutrientInput.tsx
@@ -1,0 +1,62 @@
+import { Colors } from "@/constants/colors";
+import { Typography } from "@/constants/typography";
+import { StyleSheet, Text, TextInput, View } from "react-native";
+
+type Props = {
+  label: string;
+  value: string;
+  onChange: (v: string) => void;
+  unit: string;
+};
+
+export default function NutrientInput({ label, value, onChange, unit }: Props) {
+  return (
+    <View style={styles.wrap}>
+      <Text style={styles.label}>{label}</Text>
+      <View style={styles.box}>
+        <TextInput
+          value={value}
+          onChangeText={onChange}
+          keyboardType="numeric"
+          style={styles.input}
+          placeholderTextColor={Colors.gray[300]}
+        />
+        <Text style={styles.unit}>{unit}</Text>
+      </View>
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  wrap: {
+    flex: 1,
+    gap: 8,
+  },
+  label: {
+    ...Typography.title.xs,
+    color: Colors.gray[200],
+  },
+  box: {
+    backgroundColor: "#FDFCFC1A",
+    borderRadius: 16,
+    paddingHorizontal: 12,
+    paddingVertical: 11,
+    flexDirection: "row",
+    alignItems: "center",
+    borderWidth: 1,
+    borderColor: Colors.gray[700],
+  },
+  input: {
+    flex: 1,
+    ...Typography.body.m,
+    color: Colors.gray[100],
+    padding: 0,
+    minWidth: 0,
+    textAlign: "right",
+  },
+  unit: {
+    ...Typography.body.m,
+    color: Colors.gray[100],
+    marginLeft: 2,
+  },
+});

--- a/components/quickAdd/QuickAddFoodSheet.styles.ts
+++ b/components/quickAdd/QuickAddFoodSheet.styles.ts
@@ -1,0 +1,99 @@
+import { Colors } from "@/constants/colors";
+import { Typography } from "@/constants/typography";
+import { StyleSheet } from "react-native";
+
+export const styles = StyleSheet.create({
+  root: {
+    flex: 1,
+    backgroundColor: `${Colors.gray[1000]}B3`,
+    justifyContent: "flex-end",
+  },
+  backdrop: {
+    ...StyleSheet.absoluteFillObject,
+  },
+  sheet: {
+    backgroundColor: Colors.gray[900],
+    borderTopLeftRadius: 16,
+    borderTopRightRadius: 16,
+    padding: 16,
+    gap: 16,
+  },
+  header: {
+    flexDirection: "row",
+    justifyContent: "space-between",
+    alignItems: "center",
+  },
+  title: {
+    ...Typography.title.m,
+    color: Colors.gray[100],
+  },
+  tabs: {
+    flexDirection: "row",
+    gap: 8,
+  },
+  tab: {
+    paddingHorizontal: 16,
+    paddingVertical: 8,
+    borderRadius: 16,
+  },
+  tabActive: {
+    backgroundColor: Colors.main[500],
+    shadowColor: Colors.main[400],
+    elevation: 4,
+  },
+  tabText: {
+    ...Typography.body.l,
+    color: Colors.gray[200],
+  },
+  tabTextActive: {
+    ...Typography.body.l,
+    color: Colors.gray[100],
+  },
+  formContainer: {
+    backgroundColor: "#FDFCFC0A",
+    borderRadius: 16,
+    padding: 16,
+    gap: 16,
+  },
+  fieldWrap: {
+    gap: 8,
+  },
+  fieldLabel: {
+    ...Typography.title.xs,
+    color: Colors.gray[200],
+  },
+  inputBox: {
+    backgroundColor: "#FDFCFC1A",
+    borderRadius: 16,
+    paddingHorizontal: 12,
+    paddingVertical: 11,
+    justifyContent: "center",
+    borderWidth: 1,
+    borderColor: Colors.gray[700],
+  },
+  baseInput: {
+    ...Typography.body.m,
+    color: Colors.gray[100],
+    padding: 0,
+  },
+  calorieBox: {
+    flexDirection: "row",
+    alignItems: "center",
+  },
+  calorieInput: {
+    flex: 1,
+    textAlign: "right",
+  },
+  calorieUnit: {
+    ...Typography.body.m,
+    color: Colors.gray[100],
+    marginLeft: 4,
+  },
+  nutrientRow: {
+    flexDirection: "row",
+    gap: 16,
+  },
+  nutrientSpacer: {
+    flex: 1,
+  },
+});

--- a/components/quickAdd/QuickAddFoodSheet.tsx
+++ b/components/quickAdd/QuickAddFoodSheet.tsx
@@ -1,0 +1,268 @@
+import KkButton from "@/components/KkButton";
+import KkModal from "@/components/KkModal";
+import { Ionicons } from "@expo/vector-icons";
+import { useEffect, useRef, useState } from "react";
+import {
+  Animated,
+  Keyboard,
+  Modal,
+  Platform,
+  Text,
+  TextInput,
+  TouchableOpacity,
+  View,
+} from "react-native";
+import { useSafeAreaInsets } from "react-native-safe-area-context";
+import NutrientInput from "./NutrientInput";
+import { styles } from "./QuickAddFoodSheet.styles";
+
+type MealType = "아침" | "점심" | "저녁" | "간식";
+const MEAL_TYPES: MealType[] = ["아침", "점심", "저녁", "간식"];
+
+type FormData = {
+  mealType: MealType;
+  name: string;
+  calories: string;
+  carbs: string;
+  protein: string;
+  fat: string;
+  sugar: string;
+  sodium: string;
+};
+
+const INITIAL_FORM: FormData = {
+  mealType: "아침",
+  name: "",
+  calories: "",
+  carbs: "",
+  protein: "",
+  fat: "",
+  sugar: "",
+  sodium: "",
+};
+
+type Props = {
+  visible: boolean;
+  onClose: () => void;
+  onSubmit?: (data: FormData) => void;
+};
+
+export default function QuickAddFoodSheet({
+  visible,
+  onClose,
+  onSubmit,
+}: Props) {
+  const insets = useSafeAreaInsets();
+  const slideAnim = useRef(new Animated.Value(600)).current;
+  const keyboardOffset = useRef(new Animated.Value(0)).current;
+  const [form, setForm] = useState<FormData>(INITIAL_FORM);
+  const [showExitModal, setShowExitModal] = useState(false);
+
+  const isAllFilled = (Object.keys(INITIAL_FORM) as (keyof FormData)[])
+    .filter((k) => k !== "mealType")
+    .every((k) => form[k] !== "");
+
+  useEffect(() => {
+    if (visible) {
+      Animated.spring(slideAnim, {
+        toValue: 0,
+        useNativeDriver: false,
+        damping: 22,
+        stiffness: 220,
+      }).start();
+    } else {
+      Animated.timing(slideAnim, {
+        toValue: 600,
+        duration: 220,
+        useNativeDriver: false,
+      }).start(() => setForm(INITIAL_FORM));
+    }
+  }, [visible, slideAnim]);
+
+  useEffect(() => {
+    const showEvent =
+      Platform.OS === "ios" ? "keyboardWillShow" : "keyboardDidShow";
+    const hideEvent =
+      Platform.OS === "ios" ? "keyboardWillHide" : "keyboardDidHide";
+
+    const showSub = Keyboard.addListener(showEvent, (e) => {
+      Animated.timing(keyboardOffset, {
+        toValue: e.endCoordinates.height,
+        duration: Platform.OS === "ios" ? e.duration : 250,
+        useNativeDriver: false,
+      }).start();
+    });
+
+    const hideSub = Keyboard.addListener(hideEvent, (e) => {
+      Animated.timing(keyboardOffset, {
+        toValue: 0,
+        duration: Platform.OS === "ios" ? e.duration : 200,
+        useNativeDriver: false,
+      }).start();
+    });
+
+    return () => {
+      showSub.remove();
+      hideSub.remove();
+    };
+  }, [keyboardOffset]);
+
+  const set = (key: keyof FormData) => (value: string) =>
+    setForm((prev) => ({ ...prev, [key]: value }));
+
+  const handleClose = () => {
+    if (isAllFilled) {
+      setShowExitModal(true);
+    } else {
+      onClose();
+    }
+  };
+
+  const handleSubmit = () => {
+    onSubmit?.(form);
+    onClose();
+  };
+
+  return (
+    <Modal
+      visible={visible}
+      transparent
+      animationType="none"
+      onRequestClose={handleClose}
+      statusBarTranslucent
+    >
+      <View style={styles.root}>
+        <TouchableOpacity
+          style={styles.backdrop}
+          onPress={handleClose}
+          activeOpacity={1}
+        />
+        <Animated.View
+          style={[
+            styles.sheet,
+            { paddingBottom: insets.bottom + 16 },
+            { transform: [{ translateY: slideAnim }] },
+            { marginBottom: keyboardOffset },
+          ]}
+        >
+          <View style={styles.header}>
+            <Text style={styles.title}>음식 간단하게 추가하기</Text>
+            <TouchableOpacity onPress={handleClose} hitSlop={8}>
+              <Ionicons name="close" size={24} color="#FDFCFC" />
+            </TouchableOpacity>
+          </View>
+
+          <View style={styles.tabs}>
+            {MEAL_TYPES.map((type) => (
+              <TouchableOpacity
+                key={type}
+                style={[styles.tab, form.mealType === type && styles.tabActive]}
+                onPress={() => set("mealType")(type)}
+                activeOpacity={0.7}
+              >
+                <Text
+                  style={[
+                    styles.tabText,
+                    form.mealType === type && styles.tabTextActive,
+                  ]}
+                >
+                  {type}
+                </Text>
+              </TouchableOpacity>
+            ))}
+          </View>
+
+          <View style={styles.formContainer}>
+            <View style={styles.fieldWrap}>
+              <Text style={styles.fieldLabel}>식사명</Text>
+              <View style={styles.inputBox}>
+                <TextInput
+                  value={form.name}
+                  onChangeText={set("name")}
+                  placeholder="예: 된장찌개, 닭가슴살샐러드"
+                  placeholderTextColor="#D0C7C2"
+                  style={styles.baseInput}
+                  returnKeyType="done"
+                  onSubmitEditing={Keyboard.dismiss}
+                />
+              </View>
+            </View>
+
+            <View style={styles.fieldWrap}>
+              <Text style={styles.fieldLabel}>칼로리</Text>
+              <View style={[styles.inputBox, styles.calorieBox]}>
+                <TextInput
+                  value={form.calories}
+                  onChangeText={set("calories")}
+                  keyboardType="numeric"
+                  style={[styles.baseInput, styles.calorieInput]}
+                  placeholderTextColor="#D0C7C2"
+                  returnKeyType="done"
+                  onSubmitEditing={Keyboard.dismiss}
+                />
+                <Text style={styles.calorieUnit}>kcal</Text>
+              </View>
+            </View>
+
+            <View style={styles.nutrientRow}>
+              <NutrientInput
+                label="탄수화물"
+                value={form.carbs}
+                onChange={set("carbs")}
+                unit="g"
+              />
+              <NutrientInput
+                label="단백질"
+                value={form.protein}
+                onChange={set("protein")}
+                unit="g"
+              />
+              <NutrientInput
+                label="지방"
+                value={form.fat}
+                onChange={set("fat")}
+                unit="g"
+              />
+            </View>
+
+            <View style={styles.nutrientRow}>
+              <NutrientInput
+                label="당"
+                value={form.sugar}
+                onChange={set("sugar")}
+                unit="g"
+              />
+              <NutrientInput
+                label="나트륨"
+                value={form.sodium}
+                onChange={set("sodium")}
+                unit="mg"
+              />
+              <View style={styles.nutrientSpacer} />
+            </View>
+
+            <KkButton
+              title="끼록하기"
+              disabled={!isAllFilled}
+              onPress={handleSubmit}
+              style={{ marginTop: 24 }}
+            />
+          </View>
+        </Animated.View>
+      </View>
+
+      <KkModal
+        visible={showExitModal}
+        onClose={() => setShowExitModal(false)}
+        message={"간편 추가 중이에요.\n지금 나가면 작성된 정보가 사라져요."}
+        buttonText="계속 작성하기"
+        onButtonPress={() => setShowExitModal(false)}
+        cancelText="나가기"
+        onCancelPress={() => {
+          setShowExitModal(false);
+          onClose();
+        }}
+      />
+    </Modal>
+  );
+}


### PR DESCRIPTION
## 📌 작업 내용
- 영양소 입력 전용 NutrientInput 컴포넌트 구현 (라벨 + 숫자 입력 + 단위)
- 음식 간편추가 바텀시트(QuickAddFoodSheet) 구현
  - 식사 타입 탭 선택 (아침/점심/저녁/간식)
  - 식사명, 칼로리, 탄수화물/단백질/지방/당/나트륨 입력 폼
  - 모든 입력칸 채워야 끼록하기 버튼 활성화
  - 키보드 표시 시 시트 자동 올라가는 처리
  - 입력 중 나가기 시도 시 확인 모달 표시
  - 슬라이드 업/다운 애니메이션
- 컴포넌트 / 스타일시트 파일 분리 (QuickAddFoodSheet.styles.ts, NutrientInput.tsx)

## 📷 스크린 샷
| 화면 1 | 화면 2 | 화면 3 |
|---|---|---|
| <img width="300" alt="Screenshot_1779104800" src="https://github.com/user-attachments/assets/a8960cb2-230b-4196-b164-a12fc3105eda" /> | <img width="300" alt="Screenshot_1779104825" src="https://github.com/user-attachments/assets/5357a43a-967a-48c6-82c8-4e0d5e37c25f" /> | <img width="300" alt="Screenshot_1779104829" src="https://github.com/user-attachments/assets/14e1ec4f-3da9-4556-bf92-09bc9e6925d2" /> |

## ⚠️ 참고 사항
- 폼 데이터 submit 연결은 미구현 상태

## 🔗 관련 이슈
Closes #21
