### PR TITLE
✨ [Feat] 캘린더 리포트 UI 구현

### DIFF
--- a/app/(tabs)/report.tsx
+++ b/app/(tabs)/report.tsx
@@ -1,9 +1,89 @@
-import { View, Text } from 'react-native';
+import KkBackground from "@/components/KkBackground";
+import KkLogoHeader from "@/components/KkLogoHeader";
+import MealSection from "@/components/report/MealSection";
+import MonthCalendar from "@/components/report/MonthCalendar";
+import NutritionCard from "@/components/report/NutritionCard";
+import { MOCK_MEALS, MOCK_NUTRITION } from "@/components/report/mockData";
+import { useState } from "react";
+import { Platform, ScrollView, StyleSheet } from "react-native";
+import { useSafeAreaInsets } from "react-native-safe-area-context";
 
-export default function Page() {
+function toDateKey(year: number, month: number, day: number) {
+  return `${year}-${String(month).padStart(2, "0")}-${String(day).padStart(2, "0")}`;
+}
+
+function toMonthKey(year: number, month: number) {
+  return `${year}-${String(month).padStart(2, "0")}`;
+}
+
+function getMarkedDays(year: number, month: number): number[] {
+  const prefix = toMonthKey(year, month);
+  return Object.keys(MOCK_MEALS)
+    .filter((k) => k.startsWith(prefix))
+    .map((k) => parseInt(k.split("-")[2], 10));
+}
+
+function toDateLabel(month: number, day: number) {
+  return `${month}월 ${day}일`;
+}
+
+export default function ReportPage() {
+  const insets = useSafeAreaInsets();
+  const tabBarHeight = Platform.OS === "ios" ? 60 + insets.bottom + 20 : 90;
+
+  const today = new Date();
+  const [year, setYear] = useState(today.getFullYear());
+  const [month, setMonth] = useState(today.getMonth() + 1);
+  const [selectedDay, setSelectedDay] = useState(9);
+
+  const markedDays = getMarkedDays(year, month);
+  const dateKey = toDateKey(year, month, selectedDay);
+  const nutrition = MOCK_NUTRITION[dateKey] ?? null;
+  const meals = MOCK_MEALS[dateKey] ?? [];
+  const dateLabel = toDateLabel(month, selectedDay);
+  const nutritionDateLabel = `${year}.${String(month).padStart(2, "0")}.${String(selectedDay).padStart(2, "0")}`;
+
+  const handlePrevMonth = () => {
+    if (month === 1) { setYear((y) => y - 1); setMonth(12); }
+    else setMonth((m) => m - 1);
+    setSelectedDay(1);
+  };
+
+  const handleNextMonth = () => {
+    if (month === 12) { setYear((y) => y + 1); setMonth(1); }
+    else setMonth((m) => m + 1);
+    setSelectedDay(1);
+  };
+
   return (
-    <View style={{ flex: 1, justifyContent: 'center', alignItems: 'center' }}>
-      <Text>페이지 준비 중</Text>
-    </View>
+    <KkBackground>
+      <KkLogoHeader />
+      <ScrollView
+        showsVerticalScrollIndicator={false}
+        contentContainerStyle={[styles.scroll, { paddingBottom: tabBarHeight }]}
+      >
+        <MonthCalendar
+          year={year}
+          month={month}
+          markedDays={markedDays}
+          todayDay={today.getMonth() + 1 === month && today.getFullYear() === year ? today.getDate() : -1}
+          onSelectDay={setSelectedDay}
+          onPrevMonth={handlePrevMonth}
+          onNextMonth={handleNextMonth}
+        />
+
+        {nutrition && (
+          <NutritionCard dateLabel={nutritionDateLabel} nutrition={nutrition} />
+        )}
+
+        <MealSection dateLabel={dateLabel} meals={meals} />
+      </ScrollView>
+    </KkBackground>
   );
 }
+
+const styles = StyleSheet.create({
+  scroll: {
+    gap: 16,
+  },
+});

--- a/components/report/MealCard.tsx
+++ b/components/report/MealCard.tsx
@@ -1,0 +1,69 @@
+import { Colors } from "@/constants/colors";
+import { Typography } from "@/constants/typography";
+import { Ionicons } from "@expo/vector-icons";
+import { Image, StyleSheet, Text, View } from "react-native";
+import { MealRecord } from "./types";
+
+type Props = { record: MealRecord };
+
+export default function MealCard({ record }: Props) {
+  return (
+    <View style={styles.card}>
+      {record.image ? (
+        <Image
+          source={{ uri: record.image }}
+          style={styles.image}
+          resizeMode="cover"
+        />
+      ) : (
+        <View style={[styles.image, styles.imagePlaceholder]}>
+          <Ionicons name="restaurant" size={32} color={Colors.gray[400]} />
+        </View>
+      )}
+      <View style={styles.info}>
+        <Text style={styles.nameCalories} numberOfLines={1}>
+          {record.name} {record.calories}kcal
+        </Text>
+        <Text style={styles.nutrients}>
+          🍚 {record.carbs}g | 🥩 {record.protein}g | 🐔 {record.fat}g | 🧂
+          {record.sodium}mg | 🧁 {record.sugar}g
+        </Text>
+      </View>
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  card: {
+    flexDirection: "row",
+    backgroundColor: Colors.gray[900],
+    borderRadius: 16,
+    overflow: "hidden",
+    alignItems: "center",
+    paddingVertical: 12,
+    paddingHorizontal: 16,
+    gap: 8,
+  },
+  image: {
+    width: 56,
+    height: 56,
+    borderRadius: 8,
+  },
+  imagePlaceholder: {
+    backgroundColor: Colors.gray[800],
+    alignItems: "center",
+    justifyContent: "center",
+  },
+  info: {
+    flex: 1,
+    gap: 8,
+  },
+  nameCalories: {
+    ...Typography.title.xs,
+    color: Colors.gray[200],
+  },
+  nutrients: {
+    ...Typography.caption[2],
+    color: Colors.gray[300],
+  },
+});

--- a/components/report/MealSection.tsx
+++ b/components/report/MealSection.tsx
@@ -1,0 +1,130 @@
+import { Colors } from "@/constants/colors";
+import { Typography } from "@/constants/typography";
+import { Ionicons } from "@expo/vector-icons";
+import { useState } from "react";
+import { StyleSheet, Text, TouchableOpacity, View } from "react-native";
+import MealCard from "./MealCard";
+import { MealRecord, MealType } from "./types";
+
+const MEAL_TYPES: MealType[] = ["아침", "점심", "저녁", "간식"];
+
+type Props = {
+  dateLabel: string;
+  meals: MealRecord[];
+};
+
+export default function MealSection({ dateLabel, meals }: Props) {
+  const [activeTab, setActiveTab] = useState<MealType>("아침");
+
+  const filtered = meals.filter((m) => m.mealType === activeTab);
+
+  return (
+    <View style={styles.container}>
+      <View style={styles.header}>
+        <Text style={styles.headerTitle}>{dateLabel}의 식단</Text>
+        <TouchableOpacity
+          style={styles.addButton}
+          hitSlop={8}
+          activeOpacity={0.7}
+        >
+          <Ionicons name="add" size={24} color={Colors.gray[200]} />
+        </TouchableOpacity>
+      </View>
+
+      <View style={styles.tabs}>
+        {MEAL_TYPES.map((type) => (
+          <TouchableOpacity
+            key={type}
+            style={[styles.tab, activeTab === type && styles.tabActive]}
+            onPress={() => setActiveTab(type)}
+            activeOpacity={0.7}
+          >
+            <Text
+              style={[
+                styles.tabText,
+                activeTab === type && styles.tabTextActive,
+              ]}
+            >
+              {type}
+            </Text>
+          </TouchableOpacity>
+        ))}
+      </View>
+
+      <View style={styles.list}>
+        {filtered.length === 0 ? (
+          <Text style={styles.empty}>기록된 식단이 없습니다.</Text>
+        ) : (
+          filtered.map((record) => <MealCard key={record.id} record={record} />)
+        )}
+      </View>
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  container: {
+    marginBottom: 48,
+    paddingHorizontal: 16,
+    gap: 0,
+  },
+  header: {
+    flexDirection: "row",
+    alignItems: "center",
+    marginBottom: 8,
+    gap: 8,
+  },
+  headerTitle: {
+    ...Typography.title.m,
+    color: Colors.gray[100],
+  },
+  tabs: {
+    flexDirection: "row",
+    gap: 24,
+    marginBottom: 16,
+  },
+  tab: {
+    width: 44,
+    height: 30,
+    alignItems: "center",
+    position: "relative",
+    borderBottomWidth: 2,
+    borderBottomColor: Colors.gray[300],
+  },
+  tabActive: {
+    borderBottomColor: Colors.gray[100],
+  },
+  tabText: {
+    ...Typography.body.l,
+    color: Colors.gray[300],
+  },
+  tabTextActive: {
+    ...Typography.title.xs,
+    color: Colors.gray[100],
+  },
+  tabIndicator: {
+    position: "absolute",
+    left: 0,
+    right: 0,
+    height: 2,
+    backgroundColor: Colors.gray[100],
+    borderRadius: 1,
+  },
+  list: {
+    gap: 16,
+  },
+  addButton: {
+    width: 24,
+    height: 24,
+    borderRadius: 12,
+    backgroundColor: Colors.gray[900],
+    alignItems: "center",
+    justifyContent: "center",
+  },
+  empty: {
+    ...Typography.body.l,
+    color: Colors.gray[500],
+    textAlign: "center",
+    paddingVertical: 32,
+  },
+});

--- a/components/report/MonthCalendar.tsx
+++ b/components/report/MonthCalendar.tsx
@@ -1,0 +1,186 @@
+import { Colors } from "@/constants/colors";
+import { Typography } from "@/constants/typography";
+import { Ionicons } from "@expo/vector-icons";
+import { StyleSheet, Text, TouchableOpacity, View } from "react-native";
+
+const WEEK_DAYS = ["일", "월", "화", "수", "목", "금", "토"];
+
+type Props = {
+  year: number;
+  month: number;
+  markedDays: number[];
+  todayDay: number;
+  onSelectDay: (day: number) => void;
+  onPrevMonth: () => void;
+  onNextMonth: () => void;
+};
+
+export default function MonthCalendar({
+  year,
+  month,
+  markedDays,
+  todayDay,
+  onSelectDay,
+  onPrevMonth,
+  onNextMonth,
+}: Props) {
+  const daysInMonth = new Date(year, month, 0).getDate();
+  const firstDayOfWeek = new Date(year, month - 1, 1).getDay();
+
+  const cells: (number | null)[] = [
+    ...Array(firstDayOfWeek).fill(null),
+    ...Array.from({ length: daysInMonth }, (_, i) => i + 1),
+  ];
+  while (cells.length % 7 !== 0) cells.push(null);
+
+  const rows: (number | null)[][] = [];
+  for (let i = 0; i < cells.length; i += 7) {
+    rows.push(cells.slice(i, i + 7));
+  }
+
+  return (
+    <View style={styles.container}>
+      <View style={styles.header}>
+        <TouchableOpacity onPress={onPrevMonth} hitSlop={8}>
+          <Ionicons name="chevron-back" size={20} color={Colors.gray[200]} />
+        </TouchableOpacity>
+        <Text style={styles.monthTitle}>
+          {year}.{String(month).padStart(2, "0")}
+        </Text>
+        <TouchableOpacity onPress={onNextMonth} hitSlop={8}>
+          <Ionicons name="chevron-forward" size={20} color={Colors.gray[200]} />
+        </TouchableOpacity>
+        <View style={{ flex: 1 }} />
+        <Ionicons name="bar-chart" size={22} color={Colors.gray[100]} />
+      </View>
+
+      <View style={styles.weekRow}>
+        {WEEK_DAYS.map((d, i) => (
+          <Text key={d} style={[styles.weekDay, i === 0 && styles.sunday]}>
+            {d}
+          </Text>
+        ))}
+      </View>
+
+      {rows.map((row, ri) => (
+        <View key={ri} style={styles.row}>
+          {row.map((day, ci) => {
+            const isToday = !!day && day === todayDay;
+            const isMarked = !!day && markedDays.includes(day);
+            const isSunday = ci === 0;
+
+            return (
+              <TouchableOpacity
+                key={ci}
+                style={styles.cell}
+                onPress={() => day && onSelectDay(day)}
+                disabled={!day}
+                activeOpacity={0.7}
+              >
+                <View style={styles.dayCircleWrap}>
+                  <View
+                    style={[
+                      styles.dayCircle,
+                      isMarked && styles.selectedCircle,
+                    ]}
+                  >
+                    <Text
+                      style={[
+                        styles.dayText,
+                        isSunday && !isMarked && styles.sundayText,
+                        isMarked && styles.selectedDayText,
+                        isToday && !isMarked && styles.todayDayText,
+                      ]}
+                    >
+                      {day ?? ""}
+                    </Text>
+                  </View>
+                  {isToday && !isMarked && <View style={styles.todayBorder} />}
+                </View>
+              </TouchableOpacity>
+            );
+          })}
+        </View>
+      ))}
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  container: {
+    paddingHorizontal: 16,
+    paddingVertical: 12,
+  },
+  header: {
+    flexDirection: "row",
+    alignItems: "center",
+    marginBottom: 16,
+    gap: 8,
+  },
+  monthTitle: {
+    ...Typography.title.m,
+    color: Colors.gray[100],
+  },
+  weekRow: {
+    flexDirection: "row",
+    marginBottom: 8,
+  },
+  weekDay: {
+    flex: 1,
+    textAlign: "center",
+    ...Typography.body.m,
+    color: Colors.gray[200],
+  },
+  sunday: {
+    color: Colors.main[400],
+  },
+  row: {
+    flexDirection: "row",
+  },
+  cell: {
+    flex: 1,
+    alignItems: "center",
+    paddingVertical: 4,
+    gap: 3,
+  },
+  dayCircleWrap: {
+    width: 34,
+    height: 34,
+    alignItems: "center",
+    justifyContent: "center",
+  },
+  dayCircle: {
+    width: 34,
+    height: 34,
+    borderRadius: 17,
+    overflow: "hidden",
+    alignItems: "center",
+    justifyContent: "center",
+  },
+  selectedCircle: {
+    backgroundColor: Colors.main[500],
+  },
+  todayBorder: {
+    position: "absolute",
+    top: 0,
+    left: 0,
+    right: 0,
+    bottom: 0,
+    borderRadius: 17,
+    borderWidth: 1.5,
+    borderColor: Colors.main[500],
+  },
+  dayText: {
+    ...Typography.body.l,
+    color: Colors.gray[100],
+  },
+  sundayText: {
+    color: Colors.main[400],
+  },
+  selectedDayText: {
+    color: Colors.gray[100],
+  },
+  todayDayText: {
+    color: Colors.main[500],
+  },
+});

--- a/components/report/NutritionCard.tsx
+++ b/components/report/NutritionCard.tsx
@@ -1,0 +1,106 @@
+import { Colors } from "@/constants/colors";
+import { Typography } from "@/constants/typography";
+import { StyleSheet, Text, View } from "react-native";
+import { DayNutrition } from "./types";
+
+type Props = {
+  dateLabel: string;
+  nutrition: DayNutrition;
+};
+
+function NutrientBar({
+  label,
+  value,
+  max,
+}: {
+  label: string;
+  value: number;
+  max: number;
+}) {
+  const percent = Math.min((value / max) * 100, 100);
+  return (
+    <View style={styles.barWrap}>
+      <View style={styles.barLabelRow}>
+        <Text style={styles.barLabel}>{label}</Text>
+        <Text style={styles.barValue}>
+          {value}/{max}g
+        </Text>
+      </View>
+      <View style={styles.barBg}>
+        <View style={[styles.barFill, { width: `${percent}%` }]} />
+      </View>
+    </View>
+  );
+}
+
+export default function NutritionCard({ dateLabel, nutrition }: Props) {
+  return (
+    <View style={styles.card}>
+      <View style={styles.topRow}>
+        <Text style={styles.dateText}>{dateLabel}</Text>
+        <Text style={styles.calorieText}>
+          {nutrition.calories}/{nutrition.maxCalories}kcal
+        </Text>
+      </View>
+      <NutrientBar
+        label="탄수화물"
+        value={nutrition.carbs}
+        max={nutrition.maxCarbs}
+      />
+      <NutrientBar
+        label="단백질"
+        value={nutrition.protein}
+        max={nutrition.maxProtein}
+      />
+      <NutrientBar label="지방" value={nutrition.fat} max={nutrition.maxFat} />
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  card: {
+    marginHorizontal: 16,
+    backgroundColor: Colors.gray[900],
+    borderRadius: 16,
+    padding: 16,
+    gap: 12,
+  },
+  topRow: {
+    flexDirection: "row",
+    justifyContent: "space-between",
+    alignItems: "center",
+  },
+  dateText: {
+    ...Typography.title.xs,
+    color: Colors.gray[100],
+  },
+  calorieText: {
+    ...Typography.title.xs,
+    color: Colors.gray[200],
+  },
+  barWrap: {
+    gap: 6,
+  },
+  barLabelRow: {
+    flexDirection: "row",
+    justifyContent: "space-between",
+  },
+  barLabel: {
+    ...Typography.body.m,
+    color: Colors.gray[100],
+  },
+  barValue: {
+    ...Typography.body.m,
+    color: Colors.gray[200],
+  },
+  barBg: {
+    height: 12,
+    borderRadius: 6,
+    backgroundColor: Colors.gray[600],
+  },
+  barFill: {
+    height: 12,
+    borderRadius: 6,
+    backgroundColor: Colors.main[500],
+  },
+});

--- a/components/report/mockData.ts
+++ b/components/report/mockData.ts
@@ -1,0 +1,21 @@
+import { DayNutrition, MealRecord } from "./types";
+
+export const MOCK_MEALS: Record<string, MealRecord[]> = {
+  "2026-05-03": [
+    { id: "1", name: "메뉴메뉴", calories: 450, carbs: 50, protein: 80, fat: 30, sodium: 30, sugar: 30, mealType: "아침", image: "https://via.placeholder.com/60" },
+    { id: "2", name: "메뉴메뉴", calories: 450, carbs: 50, protein: 80, fat: 30, sodium: 30, sugar: 30, mealType: "아침", image: "https://via.placeholder.com/60" },
+    { id: "3", name: "메뉴메뉴몇글자들어갈", calories: 1450, carbs: 50, protein: 80, fat: 30, sodium: 30, sugar: 30, mealType: "아침" },
+  ],
+  "2026-05-09": [
+    { id: "4", name: "비빔밥", calories: 560, carbs: 80, protein: 20, fat: 10, sodium: 500, sugar: 5, mealType: "점심", image: "https://via.placeholder.com/60" },
+  ],
+  "2026-05-13": [
+    { id: "5", name: "삼겹살", calories: 720, carbs: 10, protein: 40, fat: 55, sodium: 800, sugar: 2, mealType: "저녁", image: "https://via.placeholder.com/60" },
+  ],
+};
+
+export const MOCK_NUTRITION: Record<string, DayNutrition> = {
+  "2026-05-03": { calories: 1600, maxCalories: 2000, carbs: 89, maxCarbs: 120, protein: 89, maxProtein: 120, fat: 89, maxFat: 120 },
+  "2026-05-09": { calories: 560, maxCalories: 2000, carbs: 80, maxCarbs: 120, protein: 20, maxProtein: 120, fat: 10, maxFat: 120 },
+  "2026-05-13": { calories: 720, maxCalories: 2000, carbs: 10, maxCarbs: 120, protein: 40, maxProtein: 120, fat: 55, maxFat: 120 },
+};

--- a/components/report/types.ts
+++ b/components/report/types.ts
@@ -1,0 +1,25 @@
+export type MealType = "아침" | "점심" | "저녁" | "간식";
+
+export type MealRecord = {
+  id: string;
+  name: string;
+  calories: number;
+  carbs: number;
+  protein: number;
+  fat: number;
+  sodium: number;
+  sugar: number;
+  mealType: MealType;
+  image?: string;
+};
+
+export type DayNutrition = {
+  calories: number;
+  maxCalories: number;
+  carbs: number;
+  maxCarbs: number;
+  protein: number;
+  maxProtein: number;
+  fat: number;
+  maxFat: number;
+};

--- a/package-lock.json
+++ b/package-lock.json
@@ -19,6 +19,7 @@
         "expo-font": "~14.0.11",
         "expo-haptics": "~15.0.8",
         "expo-image": "~3.0.11",
+        "expo-keep-awake": "~15.0.8",
         "expo-linear-gradient": "~15.0.8",
         "expo-linking": "~8.0.11",
         "expo-router": "~6.0.23",

--- a/package.json
+++ b/package.json
@@ -22,6 +22,7 @@
     "expo-font": "~14.0.11",
     "expo-haptics": "~15.0.8",
     "expo-image": "~3.0.11",
+    "expo-keep-awake": "~15.0.8",
     "expo-linear-gradient": "~15.0.8",
     "expo-linking": "~8.0.11",
     "expo-router": "~6.0.23",


### PR DESCRIPTION
## 📌 작업 내용
- 리포트 탭 페이지 전체 구현 (`app/(tabs)/report.tsx`)
- 월간 캘린더 컴포넌트 구현 — 월 이동, 오늘 날짜 테두리 원, 기록 있는 날짜 채워진 원 표시
- 일별 영양 요약 카드 컴포넌트 구현 — 칼로리 및 탄수화물/단백질/지방 프로그레스 바
- 식단 카드 컴포넌트 구현 — 음식 이미지, 이름·칼로리, 영양소(이모지+구분자) 표시
- 식단 섹션 컴포넌트 구현 — 아침/점심/저녁/간식 탭 필터, 날짜별 식단 목록
- 리포트 타입 및 목데이터 정의 (`MealRecord`, `DayNutrition`, `MealType`)

## 📷 스크린 샷

| 화면 1 | 화면 2 | 화면 3 |
|---|---|---|
| <img width="300" alt="Screenshot_1779125417" src="https://github.com/user-attachments/assets/b6692360-4180-4f98-bcd3-8f4c81d261c9" /> | <img width="300" alt="Screenshot_1779125425" src="https://github.com/user-attachments/assets/d161800a-464e-4408-80da-0f6b526707b4" /> | <img width="300" alt="Screenshot_1779125427" src="https://github.com/user-attachments/assets/3b099ac4-c8c0-45dc-a6d8-a70f488ce26c" /> |

## ⚠️ 참고 사항
- Android에서 `borderRadius`가 re-render 시 적용 안 되는 버그 대응 — fill용 View에만 `overflow: hidden` 적용, today 테두리는 `position: absolute` 별도 View로 분리
- 현재 목데이터 기준으로 동작 (2026-05-03, 2026-05-09, 2026-05-13)

## 🔗 관련 이슈
Closes #22
